### PR TITLE
Switch bridge to CANserver UDP protocol

### DIFF
--- a/cmd/bridge/internal/app/bridge.go
+++ b/cmd/bridge/internal/app/bridge.go
@@ -1,35 +1,33 @@
 package app
 
 import (
-	"bufio"
+	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"sync"
 	"time"
 
 	"github.com/example/ebyte_can_ethernet_to_slcan/cmd/bridge/internal/ebyte"
-	"github.com/example/ebyte_can_ethernet_to_slcan/cmd/bridge/internal/slcan"
 )
 
 type Bridge struct {
 	cfg Config
 
 	mu      sync.RWMutex
-	clients map[*client]struct{}
+	clients map[string]*client
 
 	logger Logger
+
+	packetConn net.PacketConn
 }
 
 type client struct {
-	conn net.Conn
-	send chan string
-
-	mu     sync.Mutex
-	open   bool
-	closed bool
+	addr     net.Addr
+	version  int
+	lastSeen time.Time
 }
 
 func New(cfg Config) (*Bridge, error) {
@@ -40,177 +38,204 @@ func New(cfg Config) (*Bridge, error) {
 
 	return &Bridge{
 		cfg:     cfg,
-		clients: make(map[*client]struct{}),
+		clients: make(map[string]*client),
 		logger:  logger,
 	}, nil
 }
 
 func (b *Bridge) Run(ctx context.Context) error {
-	errCh := make(chan error, 1)
+	packetConn, err := net.ListenPacket("udp", b.cfg.ListenAddress)
+	if err != nil {
+		return fmt.Errorf("listen on %s: %w", b.cfg.ListenAddress, err)
+	}
+	defer packetConn.Close()
+	b.packetConn = packetConn
+	b.logger.Infof("CANserver UDP server listening on %s", packetConn.LocalAddr())
+
+	errCh := make(chan error, 2)
 
 	go func() {
 		errCh <- b.runAdapterLoop(ctx)
 	}()
 
-	listener, err := net.Listen("tcp", b.cfg.ListenAddress)
-	if err != nil {
-		return fmt.Errorf("listen on %s: %w", b.cfg.ListenAddress, err)
-	}
-	defer listener.Close()
-	b.logger.Infof("SLCAN server listening on %s", listener.Addr())
-
 	go func() {
-		errCh <- b.acceptClients(ctx, listener)
+		errCh <- b.handleClientPackets(ctx, packetConn)
 	}()
 
-	select {
-	case <-ctx.Done():
-		b.logger.Infof("context cancelled")
-		return nil
-	case err := <-errCh:
-		return err
-	}
-}
+	cleanupTicker := time.NewTicker(5 * time.Second)
+	defer cleanupTicker.Stop()
 
-func (b *Bridge) acceptClients(ctx context.Context, ln net.Listener) error {
-	for {
-		conn, err := ln.Accept()
-		if err != nil {
-			if ne, ok := err.(net.Error); ok && ne.Temporary() {
-				b.logger.Warnf("temporary accept error: %v", err)
-				time.Sleep(100 * time.Millisecond)
-				continue
-			}
-			return err
-		}
-
-		b.logger.Infof("client connected: %s", conn.RemoteAddr())
-		c := &client{
-			conn: conn,
-			send: make(chan string, 16),
-		}
-
-		b.mu.Lock()
-		b.clients[c] = struct{}{}
-		b.mu.Unlock()
-
-		go b.runClient(ctx, c)
-	}
-}
-
-func (b *Bridge) runClient(ctx context.Context, c *client) {
-	var wg sync.WaitGroup
-	wg.Add(2)
-
-	go func() {
-		defer wg.Done()
-		b.handleClientRead(ctx, c)
-	}()
-
-	go func() {
-		defer wg.Done()
-		b.handleClientWrite(ctx, c)
-	}()
-
-	wg.Wait()
-
-	b.mu.Lock()
-	delete(b.clients, c)
-	b.mu.Unlock()
-
-	_ = c.conn.Close()
-	b.logger.Infof("client disconnected: %s", c.conn.RemoteAddr())
-}
-
-func (b *Bridge) handleClientRead(ctx context.Context, c *client) {
-	defer func() {
-		c.mu.Lock()
-		c.closed = true
-		c.mu.Unlock()
-		close(c.send)
-	}()
-
-	scanner := bufio.NewScanner(c.conn)
-	scanner.Split(splitSLCAN)
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		cmd := slcan.ParseCommand(line)
-
-		switch cmd.Type {
-		case slcan.CommandOpen:
-			c.mu.Lock()
-			c.open = true
-			c.mu.Unlock()
-			b.logger.Debugf("client %s requested bus open", c.conn.RemoteAddr())
-			c.send <- "\r"
-		case slcan.CommandClose:
-			c.mu.Lock()
-			c.open = false
-			c.mu.Unlock()
-			b.logger.Debugf("client %s requested bus close", c.conn.RemoteAddr())
-			c.send <- "\r"
-		default:
-			b.logger.Debugf("client %s sent unsupported command %q", c.conn.RemoteAddr(), line)
-			c.send <- "\a"
-		}
-	}
-
-	if err := scanner.Err(); err != nil && !errors.Is(err, net.ErrClosed) {
-		b.logger.Warnf("client read error: %v", err)
-	}
-}
-
-func (b *Bridge) handleClientWrite(ctx context.Context, c *client) {
 	for {
 		select {
 		case <-ctx.Done():
-			return
-		case msg, ok := <-c.send:
-			if !ok {
-				return
-			}
-			if _, err := io.WriteString(c.conn, msg); err != nil {
-				b.logger.Warnf("client write error: %v", err)
-				return
-			}
+			b.logger.Infof("context cancelled")
+			return nil
+		case err := <-errCh:
+			return err
+		case <-cleanupTicker.C:
+			b.cleanupClients()
 		}
 	}
 }
 
-func splitSLCAN(data []byte, atEOF bool) (advance int, token []byte, err error) {
-	for i, b := range data {
-		if b == '\r' || b == '\n' {
-			return i + 1, data[:i], nil
+func (b *Bridge) handleClientPackets(ctx context.Context, conn net.PacketConn) error {
+	buf := make([]byte, 1024)
+	for {
+		if ctx.Err() != nil {
+			return nil
+		}
+
+		_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+		n, addr, err := conn.ReadFrom(buf)
+		if err != nil {
+			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+				continue
+			}
+			if errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			if ctx.Err() != nil {
+				return nil
+			}
+			return fmt.Errorf("read packet: %w", err)
+		}
+
+		b.processClientDatagram(conn, addr, buf[:n])
+	}
+}
+
+func (b *Bridge) processClientDatagram(conn net.PacketConn, addr net.Addr, data []byte) {
+	if len(data) == 0 {
+		return
+	}
+
+	switch {
+	case bytes.EqualFold(data, []byte("hello")):
+		b.registerClient(conn, addr, 1)
+	case bytes.EqualFold(data, []byte("ehllo")):
+		b.registerClient(conn, addr, 2)
+	case bytes.EqualFold(data, []byte("bye")):
+		b.unregisterClient(addr)
+	default:
+		b.touchClient(addr)
+	}
+}
+
+func (b *Bridge) registerClient(conn net.PacketConn, addr net.Addr, version int) {
+	key := addr.String()
+
+	var isNew bool
+
+	b.mu.Lock()
+	c, ok := b.clients[key]
+	if !ok {
+		c = &client{addr: addr}
+		b.clients[key] = c
+		isNew = true
+	}
+	prevVersion := c.version
+	c.version = version
+	c.lastSeen = time.Now()
+	b.mu.Unlock()
+
+	if isNew {
+		b.logger.Infof("client connected: %s (protocol v%d)", addr, version)
+		if err := b.sendCANserverAck(conn, addr); err != nil {
+			b.logger.Warnf("failed to send ack to %s: %v", addr, err)
+		}
+	} else if prevVersion != version {
+		b.logger.Infof("client %s switched to protocol v%d", addr, version)
+	}
+}
+
+func (b *Bridge) unregisterClient(addr net.Addr) {
+	key := addr.String()
+	b.mu.Lock()
+	if _, ok := b.clients[key]; ok {
+		delete(b.clients, key)
+		b.logger.Infof("client disconnected: %s", addr)
+	}
+	b.mu.Unlock()
+}
+
+func (b *Bridge) touchClient(addr net.Addr) {
+	key := addr.String()
+	b.mu.Lock()
+	if c, ok := b.clients[key]; ok {
+		c.lastSeen = time.Now()
+	}
+	b.mu.Unlock()
+}
+
+func (b *Bridge) cleanupClients() {
+	cutoff := time.Now().Add(-10 * time.Second)
+
+	b.mu.Lock()
+	for key, c := range b.clients {
+		if c.lastSeen.Before(cutoff) {
+			delete(b.clients, key)
+			b.logger.Infof("client timed out: %s", c.addr)
 		}
 	}
-	if atEOF && len(data) > 0 {
-		return len(data), data, nil
-	}
-	return 0, nil, nil
+	b.mu.Unlock()
+}
+
+func (b *Bridge) sendCANserverAck(conn net.PacketConn, addr net.Addr) error {
+	ack := make([]byte, 16)
+	binary.LittleEndian.PutUint32(ack[0:4], uint32(0x006<<21))
+	binary.LittleEndian.PutUint32(ack[4:8], uint32(15<<4))
+	_, err := conn.WriteTo(ack, addr)
+	return err
 }
 
 func (b *Bridge) broadcastFrame(frame ebyte.Frame) {
-	msg := slcan.EncodeFrame(frame)
+	if b.packetConn == nil {
+		return
+	}
+
+	data, err := encodeCANserverFrame(frame)
+	if err != nil {
+		b.logger.Warnf("unable to encode frame: %v", err)
+		return
+	}
 
 	b.mu.RLock()
-	defer b.mu.RUnlock()
+	clients := make([]*client, 0, len(b.clients))
+	for _, c := range b.clients {
+		clients = append(clients, c)
+	}
+	b.mu.RUnlock()
 
-	for c := range b.clients {
-		c.mu.Lock()
-		open := c.open
-		closed := c.closed
-		c.mu.Unlock()
-		if !open || closed {
+	if len(clients) == 0 {
+		return
+	}
+
+	for _, c := range clients {
+		if time.Since(c.lastSeen) > 10*time.Second {
 			continue
 		}
-
-		select {
-		case c.send <- msg:
-		default:
-			b.logger.Warnf("dropping frame for client %s due to slow consumer", c.conn.RemoteAddr())
+		if _, err := b.packetConn.WriteTo(data, c.addr); err != nil {
+			b.logger.Warnf("failed to send frame to %s: %v", c.addr, err)
 		}
 	}
+}
+
+func encodeCANserverFrame(frame ebyte.Frame) ([]byte, error) {
+	if frame.DLC > 8 {
+		return nil, fmt.Errorf("invalid DLC %d", frame.DLC)
+	}
+	if frame.Extended {
+		return nil, fmt.Errorf("extended frames are not supported")
+	}
+
+	header1 := frame.ID << 21
+	header2 := uint32(frame.DLC & 0x0F)
+
+	buf := make([]byte, 16)
+	binary.LittleEndian.PutUint32(buf[0:4], header1)
+	binary.LittleEndian.PutUint32(buf[4:8], header2)
+	copy(buf[8:], frame.Data[:])
+	return buf, nil
 }
 
 func (b *Bridge) runAdapterLoop(ctx context.Context) error {

--- a/cmd/bridge/internal/app/bridge_test.go
+++ b/cmd/bridge/internal/app/bridge_test.go
@@ -1,0 +1,64 @@
+package app
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/example/ebyte_can_ethernet_to_slcan/cmd/bridge/internal/ebyte"
+)
+
+func TestEncodeCANserverFrame(t *testing.T) {
+	frame := ebyte.Frame{
+		ID:  0x123,
+		DLC: 8,
+		Data: [8]byte{
+			0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+		},
+	}
+
+	data, err := encodeCANserverFrame(frame)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(data) != 16 {
+		t.Fatalf("expected 16-byte payload, got %d", len(data))
+	}
+
+	header1 := binary.LittleEndian.Uint32(data[0:4])
+	if header1 != frame.ID<<21 {
+		t.Fatalf("unexpected header1: got 0x%08x want 0x%08x", header1, frame.ID<<21)
+	}
+
+	header2 := binary.LittleEndian.Uint32(data[4:8])
+	if header2 != uint32(frame.DLC) {
+		t.Fatalf("unexpected header2: got 0x%08x want 0x%08x", header2, frame.DLC)
+	}
+
+	if got, want := data[8:], frame.Data[:]; !equalBytes(got, want) {
+		t.Fatalf("data mismatch: got %x want %x", got, want)
+	}
+}
+
+func TestEncodeCANserverFrameErrors(t *testing.T) {
+	_, err := encodeCANserverFrame(ebyte.Frame{DLC: 9})
+	if err == nil {
+		t.Fatalf("expected error for DLC > 8")
+	}
+
+	_, err = encodeCANserverFrame(ebyte.Frame{Extended: true})
+	if err == nil {
+		t.Fatalf("expected error for extended frame")
+	}
+}
+
+func equalBytes(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -16,8 +16,8 @@ func main() {
 	var (
 		ebyteHost      = flag.String("ebyte-host", "127.0.0.1", "Hostname or IP address of the EByte CAN-to-Ethernet adapter")
 		ebytePort      = flag.Int("ebyte-port", 4001, "TCP port of the EByte CAN-to-Ethernet adapter")
-		listenHost     = flag.String("listen-host", "0.0.0.0", "Host address for the SLCAN TCP server")
-		listenPort     = flag.Int("listen-port", 20108, "Port for the SLCAN TCP server")
+		listenHost     = flag.String("listen-host", "0.0.0.0", "Host address for the CANserver UDP server")
+		listenPort     = flag.Int("listen-port", 1338, "Port for the CANserver UDP server")
 		reconnectDelay = flag.Duration("reconnect-delay", 2*time.Second, "Delay before retrying the connection to the adapter")
 		logLevel       = flag.String("log-level", "info", "Log level (debug|info|warn|error)")
 	)


### PR DESCRIPTION
## Summary
- replace the TCP SLCAN server with a CANserver-compatible UDP service that handles hello/bye heartbeats and streams frames
- encode adapter frames into CANserver packets and cover the encoder with unit tests while updating the default CANserver port

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e4a084d45c8322973c7564da3ea39e