### PR TITLE
Support extended CAN frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
-# EByte CAN-Ethernet to SLCAN Bridge
+# EByte CAN-Ethernet to CANserver Bridge
 
-Dieses Repository enthält eine Go-Applikation, die einen EByte CAN-zu-Ethernet-Adapter mit einem TCP-Endpunkt im Lawicel/SLCAN-Format verbindet. Die Anwendung kann so als Gateway zwischen dem proprietären Binärprotokoll des Adapters und gängigen Tools wie SavvyCAN fungieren.
+Diese Go-Anwendung verbindet einen EByte CAN-zu-Ethernet-Adapter mit Clients, die das UDP-Protokoll des [CANserver](https://github.com/collin80/CANserver) sprechen (z. B. SavvyCAN). Sie übersetzt kontinuierlich zwischen dem proprietären EByte-Binärformat und den 16-Byte-CANserver-Datagrammen und hält sowohl die TCP-Verbindung zum Adapter als auch die UDP-Session der Clients stabil.
 
 ## Funktionsumfang
 
-* Baut eine ausgehende TCP-Verbindung zu einem EByte CAN-zu-Ethernet-Adapter auf und hält sie bei Verbindungsabbrüchen automatisch aufrecht.
-* Öffnet einen TCP-Listener, der angeschlossenen Clients einen Lawicel/SLCAN-kompatiblen Stream bereitstellt.
-* Wandelt CAN-Frames zwischen dem EByte-Protokoll und dem SLCAN-Textformat um.
-* Unterstützt die grundlegenden SLCAN-Kommandos `O` (open) und `C` (close) sowie Stubs für eine stabile Kommunikation.
+* Baut eine ausgehende TCP-Verbindung zum EByte CAN-zu-Ethernet-Adapter auf und versucht bei Fehlern automatisch eine Wiederverbindung.
+* Öffnet einen UDP-Listener, der eingehende CANserver-Frames entgegennimmt und Bestätigungen versendet.
+* Dekodiert empfangene Frames des Adapters (Standard- und Extended-Frames) und verteilt sie an alle aktuell verbundenen CANserver-Clients.
+  Dabei werden Identifier > 0x7FF automatisch als Extended Frames markiert, falls der Adapter das Flag nicht setzt.
+* Unterstützt sowohl das alte "hello"- als auch das neue "ehllo"-Handshake der CANserver-Protokollversionen 1 und 2.
 * Bietet strukturierte Logs mit konfigurierbaren Logleveln.
 
 ## Installation & Build
@@ -19,7 +20,7 @@ go build ./cmd/bridge
 Der resultierende Binärname kann optional mit `-o` angepasst werden:
 
 ```bash
-go build -o ebyte-slcan-bridge ./cmd/bridge
+go build -o ebyte-canserver-bridge ./cmd/bridge
 ```
 
 ## Ausführung
@@ -27,11 +28,11 @@ go build -o ebyte-slcan-bridge ./cmd/bridge
 Alle Optionen werden ausschließlich per CLI-Flags konfiguriert:
 
 ```bash
-./ebyte-slcan-bridge \
+./ebyte-canserver-bridge \
   -ebyte-host 192.0.2.10 \
   -ebyte-port 4001 \
   -listen-host 0.0.0.0 \
-  -listen-port 20108 \
+  -listen-port 1338 \
   -reconnect-delay 2s \
   -log-level info
 ```
@@ -42,14 +43,14 @@ Alle Optionen werden ausschließlich per CLI-Flags konfiguriert:
 |------|---------------|--------------|
 | `-ebyte-host` | `127.0.0.1` | Hostname oder IP des EByte-Adapters |
 | `-ebyte-port` | `4001` | TCP-Port des Adapters |
-| `-listen-host` | `0.0.0.0` | Adresse, an die der SLCAN-Server bindet |
-| `-listen-port` | `20108` | Port des SLCAN-Servers |
+| `-listen-host` | `0.0.0.0` | Adresse, an die der CANserver-kompatible UDP-Server bindet |
+| `-listen-port` | `1338` | Port des UDP-Servers |
 | `-reconnect-delay` | `2s` | Wartezeit, bevor nach Verbindungsverlust erneut verbunden wird |
 | `-log-level` | `info` | Loglevel: `debug`, `info`, `warn`, `error` |
 
 ## Nutzung mit SavvyCAN
 
-Nach dem Start der Bridge kann SavvyCAN (oder ein anderes SLCAN-kompatibles Tool) eine TCP-Verbindung zum `listen-host:listen-port` herstellen. Sobald ein Client das `O`-Kommando sendet, werden CAN-Frames zwischen Adapter und Client bidirektional übertragen.
+Nach dem Start der Bridge kann SavvyCAN unter "Connection" → "Connect" die Option **CANserver** wählen und die in `listen-host:listen-port` konfigurierte Adresse angeben. Nach erfolgreichem Handshake werden die vom Adapter empfangenen CAN-Frames an alle verbundenen Clients verteilt.
 
 ## Tests
 

--- a/cmd/bridge/internal/app/bridge.go
+++ b/cmd/bridge/internal/app/bridge.go
@@ -224,12 +224,42 @@ func encodeCANserverFrame(frame ebyte.Frame) ([]byte, error) {
 	if frame.DLC > 8 {
 		return nil, fmt.Errorf("invalid DLC %d", frame.DLC)
 	}
-	if frame.Extended {
-		return nil, fmt.Errorf("extended frames are not supported")
+
+	const (
+		idShift          = 21
+		idMask           = uint32(0x7FF)
+		timestampMask    = uint32(0x1FFFFF)
+		extendedFlagMask = uint32(1 << 31)
+		remoteFlagMask   = uint32(1 << 30)
+	)
+
+	extended := frame.Extended
+	if frame.ID > 0x7FF {
+		extended = true
 	}
 
-	header1 := frame.ID << 21
+	if extended {
+		if frame.ID > 0x1FFFFFFF {
+			return nil, fmt.Errorf("invalid extended identifier 0x%x", frame.ID)
+		}
+	}
+
+	// CANserver protocol v2 packs the 29-bit identifier across the two header words.
+	// The upper 11 bits occupy bits 21-31 of the first word, while the lower 21 bits
+	// are stored in the timestamp field (bits 0-20) when the extended flag is set.
+	header1 := (frame.ID & idMask) << idShift
+	if extended {
+		upper := (frame.ID >> idShift) & uint32(idMask)
+		header1 = (upper << idShift) | (frame.ID & timestampMask)
+	}
+
 	header2 := uint32(frame.DLC & 0x0F)
+	if extended {
+		header2 |= extendedFlagMask
+	}
+	if frame.Remote {
+		header2 |= remoteFlagMask
+	}
 
 	buf := make([]byte, 16)
 	binary.LittleEndian.PutUint32(buf[0:4], header1)

--- a/cmd/bridge/internal/app/bridge_test.go
+++ b/cmd/bridge/internal/app/bridge_test.go
@@ -9,11 +9,9 @@ import (
 
 func TestEncodeCANserverFrame(t *testing.T) {
 	frame := ebyte.Frame{
-		ID:  0x123,
-		DLC: 8,
-		Data: [8]byte{
-			0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
-		},
+		ID:   0x123,
+		DLC:  8,
+		Data: [8]byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88},
 	}
 
 	data, err := encodeCANserverFrame(frame)
@@ -39,15 +37,86 @@ func TestEncodeCANserverFrame(t *testing.T) {
 	}
 }
 
+func TestEncodeCANserverFrameExtended(t *testing.T) {
+	frame := ebyte.Frame{
+		ID:       0x1ABCDEF,
+		Extended: true,
+		DLC:      6,
+		Data:     [8]byte{0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED},
+	}
+
+	data, err := encodeCANserverFrame(frame)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(data) != 16 {
+		t.Fatalf("expected 16-byte payload, got %d", len(data))
+	}
+
+	header1 := binary.LittleEndian.Uint32(data[0:4])
+	upper := (frame.ID >> 21) & 0x7FF
+	lower := frame.ID & 0x1FFFFF
+	expectedHeader1 := (uint32(upper) << 21) | uint32(lower)
+	if header1 != expectedHeader1 {
+		t.Fatalf("unexpected header1 for extended frame: got 0x%08x want 0x%08x", header1, expectedHeader1)
+	}
+
+	header2 := binary.LittleEndian.Uint32(data[4:8])
+	const extendedFlag = uint32(1 << 31)
+	expectedHeader2 := uint32(frame.DLC) | extendedFlag
+	if header2 != expectedHeader2 {
+		t.Fatalf("unexpected header2 for extended frame: got 0x%08x want 0x%08x", header2, expectedHeader2)
+	}
+
+	if got, want := data[8:], frame.Data[:]; !equalBytes(got, want) {
+		t.Fatalf("data mismatch: got %x want %x", got, want)
+	}
+}
+
+func TestEncodeCANserverFrameRemote(t *testing.T) {
+	frame := ebyte.Frame{
+		ID:     0x321,
+		DLC:    3,
+		Remote: true,
+	}
+
+	data, err := encodeCANserverFrame(frame)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	header2 := binary.LittleEndian.Uint32(data[4:8])
+	const remoteFlag = uint32(1 << 30)
+	expectedHeader2 := uint32(frame.DLC) | remoteFlag
+	if header2 != expectedHeader2 {
+		t.Fatalf("unexpected header2 for remote frame: got 0x%08x want 0x%08x", header2, expectedHeader2)
+	}
+}
+
 func TestEncodeCANserverFrameErrors(t *testing.T) {
 	_, err := encodeCANserverFrame(ebyte.Frame{DLC: 9})
 	if err == nil {
 		t.Fatalf("expected error for DLC > 8")
 	}
 
-	_, err = encodeCANserverFrame(ebyte.Frame{Extended: true})
+	_, err = encodeCANserverFrame(ebyte.Frame{Extended: true, ID: 0x20000000})
 	if err == nil {
-		t.Fatalf("expected error for extended frame")
+		t.Fatalf("expected error for invalid extended identifier")
+	}
+}
+
+func TestEncodeCANserverFrameAutoExtended(t *testing.T) {
+	frame := ebyte.Frame{ID: 0x1ABCDE, DLC: 2}
+
+	data, err := encodeCANserverFrame(frame)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	header2 := binary.LittleEndian.Uint32(data[4:8])
+	const extendedFlag = uint32(1 << 31)
+	if header2&extendedFlag == 0 {
+		t.Fatalf("expected extended flag to be set for identifier 0x%x", frame.ID)
 	}
 }
 

--- a/cmd/bridge/internal/ebyte/frame_test.go
+++ b/cmd/bridge/internal/ebyte/frame_test.go
@@ -15,13 +15,37 @@ func TestParseFrame(t *testing.T) {
 	if frame.Remote {
 		t.Fatalf("expected data frame")
 	}
-	if frame.Extended {
-		t.Fatalf("expected standard frame")
+	if !frame.Extended {
+		t.Fatalf("expected extended frame")
 	}
 	if frame.ID != 0x12345678 {
 		t.Fatalf("unexpected ID %08x", frame.ID)
 	}
 	if frame.Data[0] != 0x11 || frame.Data[7] != 0x88 {
+		t.Fatalf("unexpected data payload %x", frame.Data)
+	}
+}
+
+func TestParseFrameStandard(t *testing.T) {
+	raw := []byte{0x06, 0x00, 0x00, 0x03, 0xF0, 0xAA, 0xBB, 0xCC, 0xDD, 0x00, 0x00, 0x00, 0x00}
+	frame, err := ParseFrame(raw)
+	if err != nil {
+		t.Fatalf("ParseFrame returned error: %v", err)
+	}
+
+	if frame.Extended {
+		t.Fatalf("expected standard frame")
+	}
+	if frame.Remote {
+		t.Fatalf("expected data frame")
+	}
+	if frame.DLC != 6 {
+		t.Fatalf("expected DLC 6, got %d", frame.DLC)
+	}
+	if frame.ID != 0x3F0 {
+		t.Fatalf("unexpected ID %08x", frame.ID)
+	}
+	if frame.Data[0] != 0xAA || frame.Data[3] != 0xDD {
 		t.Fatalf("unexpected data payload %x", frame.Data)
 	}
 }
@@ -51,5 +75,34 @@ func TestSerializeFrame(t *testing.T) {
 
 	if parsed.ID != frame.ID || parsed.DLC != frame.DLC || !parsed.Extended {
 		t.Fatalf("parsed frame mismatch: %+v", parsed)
+	}
+}
+
+func TestSerializeFrameRemote(t *testing.T) {
+	frame := Frame{
+		ID:     0x123,
+		DLC:    2,
+		Remote: true,
+	}
+
+	raw, err := SerializeFrame(frame)
+	if err != nil {
+		t.Fatalf("SerializeFrame returned error: %v", err)
+	}
+
+	if raw[0]&0x40 == 0 {
+		t.Fatalf("expected remote flag to be set in header byte")
+	}
+
+	parsed, err := ParseFrame(raw)
+	if err != nil {
+		t.Fatalf("ParseFrame returned error: %v", err)
+	}
+
+	if !parsed.Remote {
+		t.Fatalf("expected remote frame, got %+v", parsed)
+	}
+	if parsed.ID != frame.ID {
+		t.Fatalf("unexpected identifier: got 0x%x want 0x%x", parsed.ID, frame.ID)
 	}
 }


### PR DESCRIPTION
## Summary
- update the CANserver frame encoder to support extended identifiers, remote frames, and to automatically flag identifiers wider than 11 bits as extended when required
- add unit tests covering standard, extended, remote, auto-detected extended, and invalid frame scenarios
- document extended-frame forwarding in the README, including automatic detection when the adapter omits the extended flag
- align the EBYTE frame parser and serializer with the adapter's frame-info byte so extended and remote flags are interpreted correctly while rejecting oversized DLC values

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e4a73f038c83229b7a4f5273b8676a