### PR TITLE
Document bridge components and extend tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# EByte CAN-Ethernet zu GVRET-Bridge
+# EByte CAN-Ethernet to GVRET Bridge
 
-Diese Go-Anwendung verbindet einen EByte CAN-zu-Ethernet-Adapter mit Clients, die das TCP-basierte GVRET-Protokoll (z. B. [SavvyCAN](https://github.com/collin80/SavvyCAN)) sprechen. Sie übersetzt kontinuierlich zwischen dem proprietären EByte-Binärformat und den GVRET-Nachrichten und hält sowohl die TCP-Verbindung zum Adapter als auch die GVRET-Session der Clients stabil.
+This Go application connects an EByte CAN-to-Ethernet adapter with clients that speak the TCP-based GVRET protocol (e.g. [SavvyCAN](https://github.com/collin80/SavvyCAN)). It continuously translates between the proprietary EByte binary format and GVRET messages while keeping both the TCP connection to the adapter and the GVRET session with clients alive.
 
-## Funktionsumfang
+## Features
 
-* Baut eine ausgehende TCP-Verbindung zum EByte CAN-zu-Ethernet-Adapter auf und versucht bei Fehlern automatisch eine Wiederverbindung.
-* Öffnet einen TCP-Listener, der GVRET-Clients akzeptiert, das GVRET-Handshake bedient und periodische Validierungsanfragen beantwortet.
-* Dekodiert empfangene Frames des Adapters (Standard- und Extended-Frames) und verteilt sie an alle aktuell verbundenen GVRET-Clients.
-  Dabei werden Identifier > 0x7FF automatisch als Extended Frames markiert, falls der Adapter das Flag nicht setzt.
-* Meldet dem Client eine konfigurierbare Busgeschwindigkeit und liefert GVRET-Zeitstempel auf Basis der Systemuhr.
-* Bietet strukturierte Logs mit konfigurierbaren Logleveln.
+* Establishes an outgoing TCP connection to the EByte CAN-to-Ethernet adapter and automatically retries when the link drops.
+* Opens a TCP listener that accepts GVRET clients, performs the GVRET handshake, and responds to periodic validation requests.
+* Decodes adapter frames (standard and extended) and distributes them to all currently connected GVRET clients.
+  Identifiers greater than 0x7FF are automatically flagged as extended frames if the adapter omits the flag.
+* Reports a configurable bus bitrate to the client and provides GVRET timestamps based on the system clock.
+* Offers structured logging with configurable log levels.
 
 ## Installation & Build
 
@@ -17,15 +17,15 @@ Diese Go-Anwendung verbindet einen EByte CAN-zu-Ethernet-Adapter mit Clients, di
 go build ./cmd/bridge
 ```
 
-Der resultierende Binärname kann optional mit `-o` angepasst werden:
+The name of the resulting binary can optionally be adjusted via `-o`:
 
 ```bash
 go build -o ebyte-canserver-bridge ./cmd/bridge
 ```
 
-## Ausführung
+## Usage
 
-Alle Optionen werden ausschließlich per CLI-Flags konfiguriert:
+All options are configured via CLI flags only:
 
 ```bash
 ./ebyte-canserver-bridge \
@@ -38,30 +38,30 @@ Alle Optionen werden ausschließlich per CLI-Flags konfiguriert:
   -log-level info
 ```
 
-### Wichtige Flags
+### Important Flags
 
-| Flag | Standardwert | Beschreibung |
-|------|---------------|--------------|
-| `-ebyte-host` | `127.0.0.1` | Hostname oder IP des EByte-Adapters |
-| `-ebyte-port` | `4001` | TCP-Port des Adapters |
-| `-listen-host` | `0.0.0.0` | Adresse, an die der GVRET-TCP-Server bindet |
-| `-listen-port` | `23` | Port des TCP-Servers |
-| `-can-bitrate` | `500000` | Gemeldete CAN-Bitrate für GVRET-Clients (in bit/s) |
-| `-reconnect-delay` | `2s` | Wartezeit, bevor nach Verbindungsverlust erneut verbunden wird |
-| `-log-level` | `info` | Loglevel: `debug`, `info`, `warn`, `error` |
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-ebyte-host` | `127.0.0.1` | Hostname or IP address of the EByte adapter |
+| `-ebyte-port` | `4001` | TCP port of the adapter |
+| `-listen-host` | `0.0.0.0` | Address the GVRET TCP server binds to |
+| `-listen-port` | `23` | Port of the TCP server |
+| `-can-bitrate` | `500000` | CAN bitrate reported to GVRET clients (in bit/s) |
+| `-reconnect-delay` | `2s` | Waiting time before reconnecting after a disconnect |
+| `-log-level` | `info` | Log level: `debug`, `info`, `warn`, `error` |
 
-## Nutzung mit SavvyCAN
+## Using SavvyCAN
 
-Nach dem Start der Bridge kann SavvyCAN unter "Connection" → "Connect" die Option **GVRET** wählen und die in `listen-host:listen-port` konfigurierte Adresse angeben. Die Bridge beantwortet das GVRET-Handshake (inklusive Validierungspakete) und verteilt danach die vom Adapter empfangenen CAN-Frames an alle verbundenen Clients.
+After starting the bridge, choose **GVRET** under "Connection" → "Connect" in SavvyCAN and point it to the `listen-host:listen-port` pair. The bridge completes the GVRET handshake (including validation packets) and then forwards the CAN frames received from the adapter to all connected clients.
 
 ## Tests
 
-Zum Ausführen der vorhandenen Unit-Tests:
+Run the available unit tests with:
 
 ```bash
 go test ./...
 ```
 
-## Lizenz
+## License
 
-Die Software steht unter der MIT-Lizenz. Details siehe [LICENSE](LICENSE).
+The software is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/cmd/bridge/internal/app/config.go
+++ b/cmd/bridge/internal/app/config.go
@@ -2,10 +2,11 @@ package app
 
 import "time"
 
+// Config collects runtime settings for the bridge.
 type Config struct {
-        EByteAddress   string
-        ListenAddress  string
-        ReconnectDelay time.Duration
-        LogLevel       string
-        BusBitrate     uint32
+	EByteAddress   string
+	ListenAddress  string
+	ReconnectDelay time.Duration
+	LogLevel       string
+	BusBitrate     uint32
 }

--- a/cmd/bridge/internal/app/logger.go
+++ b/cmd/bridge/internal/app/logger.go
@@ -18,9 +18,13 @@ const (
 )
 
 type Logger interface {
+	// Debugf logs a debug-level message.
 	Debugf(format string, args ...any)
+	// Infof logs an info-level message.
 	Infof(format string, args ...any)
+	// Warnf logs a warning message.
 	Warnf(format string, args ...any)
+	// Errorf logs an error-level message.
 	Errorf(format string, args ...any)
 }
 
@@ -29,6 +33,8 @@ type stdLogger struct {
 	l     *log.Logger
 }
 
+// NewLogger creates a logger instance that writes to stdout with the requested
+// minimum level.
 func NewLogger(level string) (Logger, error) {
 	lvl, err := parseLevel(level)
 	if err != nil {
@@ -40,6 +46,7 @@ func NewLogger(level string) (Logger, error) {
 	return sl, nil
 }
 
+// parseLevel converts the textual representation into the internal log level.
 func parseLevel(level string) (LogLevel, error) {
 	switch strings.ToLower(level) {
 	case "debug":

--- a/cmd/bridge/internal/ebyte/frame.go
+++ b/cmd/bridge/internal/ebyte/frame.go
@@ -1,3 +1,5 @@
+// Package ebyte contains helpers for working with the proprietary
+// EByte CAN-to-Ethernet frame format.
 package ebyte
 
 import (
@@ -5,8 +7,11 @@ import (
 	"fmt"
 )
 
+// FrameSize defines the fixed size of the binary frames exchanged with the
+// EByte adapter.
 const FrameSize = 13
 
+// Frame represents a CAN frame in the EByte binary wire format.
 type Frame struct {
 	ID       uint32
 	Extended bool
@@ -15,6 +20,8 @@ type Frame struct {
 	Data     [8]byte
 }
 
+// ParseFrame converts the 13-byte binary frame emitted by the adapter into a
+// structured Frame instance.
 func ParseFrame(raw []byte) (Frame, error) {
 	if len(raw) != FrameSize {
 		return Frame{}, fmt.Errorf("invalid frame size %d", len(raw))
@@ -35,6 +42,8 @@ func ParseFrame(raw []byte) (Frame, error) {
 	return frame, nil
 }
 
+// SerializeFrame converts a structured Frame into the 13-byte binary
+// representation expected by the adapter.
 func SerializeFrame(frame Frame) ([]byte, error) {
 	if frame.DLC > 8 {
 		return nil, fmt.Errorf("invalid DLC %d", frame.DLC)

--- a/cmd/bridge/internal/ebyte/frame_test.go
+++ b/cmd/bridge/internal/ebyte/frame_test.go
@@ -106,3 +106,24 @@ func TestSerializeFrameRemote(t *testing.T) {
 		t.Fatalf("unexpected identifier: got 0x%x want 0x%x", parsed.ID, frame.ID)
 	}
 }
+
+func TestParseFrameInvalidSize(t *testing.T) {
+	if _, err := ParseFrame([]byte{0x00}); err == nil {
+		t.Fatalf("expected error for truncated frame")
+	}
+}
+
+func TestParseFrameInvalidDLC(t *testing.T) {
+	raw := []byte{0x89}
+	raw = append(raw, make([]byte, FrameSize-1)...)
+	if _, err := ParseFrame(raw); err == nil {
+		t.Fatalf("expected error for DLC > 8")
+	}
+}
+
+func TestSerializeFrameInvalidDLC(t *testing.T) {
+	_, err := SerializeFrame(Frame{DLC: 9})
+	if err == nil {
+		t.Fatalf("expected error for invalid DLC")
+	}
+}

--- a/cmd/bridge/internal/slcan/command.go
+++ b/cmd/bridge/internal/slcan/command.go
@@ -13,6 +13,9 @@ type Command struct {
 	Raw  string
 }
 
+// ParseCommand inspects the ASCII command string sent by a GVRET client and
+// categorises it into a known command type. Unknown commands are reported with
+// their raw representation so the caller can decide how to handle them.
 func ParseCommand(raw string) Command {
 	if raw == "" {
 		return Command{Type: CommandUnknown, Raw: raw}

--- a/cmd/bridge/internal/slcan/command_test.go
+++ b/cmd/bridge/internal/slcan/command_test.go
@@ -20,3 +20,11 @@ func TestParseCommand(t *testing.T) {
 		}
 	}
 }
+
+func TestParseCommandKeepsRaw(t *testing.T) {
+	input := "O123"
+	cmd := ParseCommand(input)
+	if cmd.Raw != input {
+		t.Fatalf("expected raw command to be preserved, got %q", cmd.Raw)
+	}
+}

--- a/cmd/bridge/internal/slcan/frame.go
+++ b/cmd/bridge/internal/slcan/frame.go
@@ -1,3 +1,5 @@
+// Package slcan implements helpers for the serial CAN (SLCAN) textual
+// protocol that GVRET clients understand.
 package slcan
 
 import (
@@ -7,6 +9,8 @@ import (
 	"github.com/example/ebyte_can_ethernet_to_slcan/cmd/bridge/internal/ebyte"
 )
 
+// EncodeFrame converts an internal CAN frame into the ASCII SLCAN string that
+// GVRET-compatible clients expect.
 func EncodeFrame(frame ebyte.Frame) string {
 	var builder strings.Builder
 	switch {

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -1,3 +1,4 @@
+// Command bridge starts the EByte CAN-to-GVRET bridge application.
 package main
 
 import (
@@ -12,26 +13,27 @@ import (
 	"github.com/example/ebyte_can_ethernet_to_slcan/cmd/bridge/internal/app"
 )
 
+// main parses CLI flags, initialises the bridge and blocks until shutdown.
 func main() {
 	var (
 		ebyteHost      = flag.String("ebyte-host", "127.0.0.1", "Hostname or IP address of the EByte CAN-to-Ethernet adapter")
 		ebytePort      = flag.Int("ebyte-port", 4001, "TCP port of the EByte CAN-to-Ethernet adapter")
-                listenHost     = flag.String("listen-host", "0.0.0.0", "Host address for the GVRET TCP server")
-                listenPort     = flag.Int("listen-port", 23, "Port for the GVRET TCP server")
-                reconnectDelay = flag.Duration("reconnect-delay", 2*time.Second, "Delay before retrying the connection to the adapter")
-                logLevel       = flag.String("log-level", "info", "Log level (debug|info|warn|error)")
-                busBitrate     = flag.Uint("can-bitrate", 500000, "Nominal CAN bitrate used to announce the GVRET bus (in bit/s)")
+		listenHost     = flag.String("listen-host", "0.0.0.0", "Host address for the GVRET TCP server")
+		listenPort     = flag.Int("listen-port", 23, "Port for the GVRET TCP server")
+		reconnectDelay = flag.Duration("reconnect-delay", 2*time.Second, "Delay before retrying the connection to the adapter")
+		logLevel       = flag.String("log-level", "info", "Log level (debug|info|warn|error)")
+		busBitrate     = flag.Uint("can-bitrate", 500000, "Nominal CAN bitrate used to announce the GVRET bus (in bit/s)")
 	)
 
 	flag.Parse()
 
 	cfg := app.Config{
 		EByteAddress:   fmt.Sprintf("%s:%d", *ebyteHost, *ebytePort),
-                ListenAddress:  fmt.Sprintf("%s:%d", *listenHost, *listenPort),
-                ReconnectDelay: *reconnectDelay,
-                LogLevel:       *logLevel,
-                BusBitrate:     uint32(*busBitrate),
-        }
+		ListenAddress:  fmt.Sprintf("%s:%d", *listenHost, *listenPort),
+		ReconnectDelay: *reconnectDelay,
+		LogLevel:       *logLevel,
+		BusBitrate:     uint32(*busBitrate),
+	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()


### PR DESCRIPTION
## Summary
- translate the README to English for broader accessibility
- add inline documentation across the bridge, SLCAN, and logging packages
- extend unit coverage for EByte frame parsing/serialization and SLCAN command handling

## Testing
- GOTOOLCHAIN=local go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e4d36ac56483228e8efae55ae03ce8